### PR TITLE
Makefile: remote SILENT and IGNORE

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,9 +1,6 @@
 SHELL=/bin/sh
 PACKAGE_NAME={{ cookiecutter.repo_name }}
 
-.SILENT:
-.IGNORE:
-
 .PHONY: help
 help:
 	echo
@@ -40,8 +37,8 @@ test-slow:
 clean:
 	echo Cleaning ...
 	rm -rf build/
-	find ./$(PACKAGE_NAME)/ -name "__pycache__" -exec rm -rf {} \;
-	find ./$(PACKAGE_NAME)/ -name "*.pyc" -exec rm -rf {} \;
+	-find ./$(PACKAGE_NAME)/ -name "__pycache__" -exec rm -rf {} \;
+	-find ./$(PACKAGE_NAME)/ -name "*.pyc" -exec rm -rf {} \;
 	echo ... done
 
 .PHONY: install-deps
@@ -54,7 +51,7 @@ develop: install-deps
 
 .PHONY: uninstall
 uninstall:
-	pip uninstall --yes $(PACKAGE_NAME)
+	-pip uninstall --yes $(PACKAGE_NAME)
 	rm -rf *.egg-info/
 
 #--system-site-packages plugin issue workaround


### PR DESCRIPTION
.IGNORE means that Make ignores errors.
This means that running `make test` exits with zero exit code even
tests fail. This means it is no good for continuous integration,
Automated systems like Jenkins and Travis depend on exit codes to
detect failures.

.SILENT means that Make suppresses printing out what it will run.

If we want to ignore errors for some Make tasks we can prefix them
with a hyphen, see
https://www.gnu.org/software/make/manual/make.html#Errors

If we want to suppress printing particular commands, we can prefix
them with '@':
https://www.gnu.org/software/make/manual/make.html#Echoing